### PR TITLE
Hashing and Symmetric Cipher API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     - Maybe use https://hackage.haskell.org/package/aeson-better-errors
 - [ ] Continue Yesod book next section: https://www.yesodweb.com/book/shakespearean-templates
 - [ ] Something with cryponite
+  - Working on a hashing API in src/Handler/Hash.hs
 - [ ] Something with megaparsec
 - [ ] Something with unliftio
 

--- a/config/routes.yesodroutes
+++ b/config/routes.yesodroutes
@@ -22,4 +22,6 @@
 -- ?base=base{16,32,64} [default: base16]
 /api/hash/#Text/#Text HashR GET
 
-/api/cipher/aes256 CipherR POST
+/api/cipher/aes256/#Text CipherR GET
+
+/api/decipher/aes256/#Text DecipherR GET

--- a/config/routes.yesodroutes
+++ b/config/routes.yesodroutes
@@ -19,4 +19,7 @@
 
 /api/donor/#Int64 DonorByIdR GET DELETE PUT
 
+-- ?base=base{16,32,64} [default: base16]
 /api/hash/#Text/#Text HashR GET
+
+/api/cipher/aes256 CipherR POST

--- a/config/routes.yesodroutes
+++ b/config/routes.yesodroutes
@@ -18,3 +18,5 @@
 /api/donor DonorR POST GET
 
 /api/donor/#Int64 DonorByIdR GET DELETE PUT
+
+/api/hash/#Text/#Text HashR GET

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
 - case-insensitive
 - wai
 - foreign-store
+- cryptonite
 
 # The library contains all of our application code. The executable
 # defined below is just a thin wrapper.

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ dependencies:
 - foreign-store
 - cryptonite
 - memory
+- base64
 
 # The library contains all of our application code. The executable
 # defined below is just a thin wrapper.

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ dependencies:
 - wai
 - foreign-store
 - cryptonite
+- memory
 
 # The library contains all of our application code. The executable
 # defined below is just a thin wrapper.

--- a/src/Data/Cipher.hs
+++ b/src/Data/Cipher.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Data.Cipher where
+
+import Crypto.Cipher.Types (BlockCipher (..), Cipher (..), IV, makeIV)
+import Crypto.Error (CryptoError (..), CryptoFailable (..))
+import qualified Crypto.Random.Types as CRT
+import Data.ByteArray (ByteArray)
+import Data.ByteString (ByteString)
+
+data Key c a where
+    Key :: (BlockCipher c, ByteArray a) => a -> Key c a
+
+-- | Generates a string of bytes (key) of a specific length for a given block cipher
+genSecretKey :: forall m c a. (CRT.MonadRandom m, BlockCipher c, ByteArray a) => c -> Int -> m (Key c a)
+genSecretKey _ = fmap Key . CRT.getRandomBytes
+
+-- | Generate a random initialization vector for a given block cipher
+genRandomIV :: forall m c. (CRT.MonadRandom m, BlockCipher c) => c -> m (Maybe (IV c))
+genRandomIV _ = makeIV <$> (CRT.getRandomBytes @_ @ByteString $ blockSize (undefined :: c))
+
+-- | Initialize a block cipher
+initCipher :: (BlockCipher c, ByteArray a) => Key c a -> Either CryptoError c
+initCipher (Key k) = case cipherInit k of
+    CryptoFailed e -> Left e
+    CryptoPassed a -> Right a
+
+encrypt :: (BlockCipher c, ByteArray a) => Key c a -> IV c -> a -> Either CryptoError a
+encrypt secretKey initIV msg =
+    case initCipher secretKey of
+        Left e -> Left e
+        Right c -> Right $ ctrCombine c initIV msg
+
+decrypt :: (BlockCipher c, ByteArray a) => Key c a -> IV c -> a -> Either CryptoError a
+decrypt = encrypt

--- a/src/Data/Cipher.hs
+++ b/src/Data/Cipher.hs
@@ -10,9 +10,14 @@ import Crypto.Error (CryptoError (..), CryptoFailable (..))
 import qualified Crypto.Random.Types as CRT
 import Data.ByteArray (ByteArray)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base64.URL as Base64
+import Data.Text (Text)
 
 data Key c a where
     Key :: (BlockCipher c, ByteArray a) => a -> Key c a
+
+showSecretKey :: BlockCipher c => Key c ByteString -> Text
+showSecretKey (Key bs) = Base64.encodeBase64 bs
 
 -- | Generates a string of bytes (key) of a specific length for a given block cipher
 genSecretKey :: forall m c a. (CRT.MonadRandom m, BlockCipher c, ByteArray a) => c -> Int -> m (Key c a)

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -194,7 +194,8 @@ instance Yesod App where
     isAuthorized DonorR _ = return Authorized
     isAuthorized (DonorByIdR _) _ = return Authorized
     isAuthorized (HashR _ _) _ = return Authorized
-    isAuthorized CipherR _ = return Authorized
+    isAuthorized (CipherR _) _ = return Authorized
+    isAuthorized (DecipherR _) _ = return Authorized
     -- the profile route requires that the user is authenticated, so we
     -- delegate to that function
     isAuthorized ProfileR _ = isAuthenticated

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -19,7 +19,10 @@ import Text.Jasmine (minifym)
 -- Used only when in "auth-dummy-login" setting is enabled.
 import Yesod.Auth.Dummy
 
+import Crypto.Cipher.AES (AES256)
+import Crypto.Cipher.Types (IV)
 import qualified Data.CaseInsensitive as CI
+import qualified Data.Cipher as Cipher
 import qualified Data.Text.Encoding as TE
 import Yesod.Auth.OpenId (IdentifierType (Claimed), authOpenId)
 import Yesod.Core.Types (Logger)
@@ -39,6 +42,8 @@ data App = App
       appConnPool :: ConnectionPool
     , appHttpManager :: Manager
     , appLogger :: Logger
+    , appCipherSecretKey :: Cipher.Key AES256 ByteString
+    , appCipherInitializationVector :: IV AES256
     }
 
 data MenuItem = MenuItem
@@ -188,6 +193,8 @@ instance Yesod App where
     isAuthorized AboutR _ = return Authorized
     isAuthorized DonorR _ = return Authorized
     isAuthorized (DonorByIdR _) _ = return Authorized
+    isAuthorized (HashR _ _) _ = return Authorized
+    isAuthorized CipherR _ = return Authorized
     -- the profile route requires that the user is authenticated, so we
     -- delegate to that function
     isAuthorized ProfileR _ = isAuthenticated

--- a/src/Handler/Cipher.hs
+++ b/src/Handler/Cipher.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Handler.Cipher where
+
+import qualified Data.Cipher as Cipher
+import qualified Data.Text.Encoding as Text
+import Import
+
+data Message = Message {msg :: Text} deriving (Generic, FromJSON)
+
+postCipherR :: HandlerFor App Value
+postCipherR = do
+    App{appCipherSecretKey = sk, appCipherInitializationVector = iv} <- getYesod
+    Message{..} <- requireCheckJsonBody :: Handler Message
+    case Cipher.encrypt sk iv (Text.encodeUtf8 msg) of
+        Left _ -> sendStatusJSON internalServerError500 $ object ["msg" .= ("Unable to encrypt input" :: Text)]
+        Right eMsg ->
+            pure $
+                object
+                    [ "message" .= msg
+                    , "encrypted" .= show eMsg
+                    ]

--- a/src/Handler/Cipher.hs
+++ b/src/Handler/Cipher.hs
@@ -6,21 +6,19 @@
 
 module Handler.Cipher where
 
+import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.Cipher as Cipher
 import qualified Data.Text.Encoding as Text
 import Import
 
-data Message = Message {msg :: Text} deriving (Generic, FromJSON)
-
-postCipherR :: HandlerFor App Value
-postCipherR = do
+getCipherR :: Text -> HandlerFor App Value
+getCipherR msg = do
     App{appCipherSecretKey = sk, appCipherInitializationVector = iv} <- getYesod
-    Message{..} <- requireCheckJsonBody :: Handler Message
     case Cipher.encrypt sk iv (Text.encodeUtf8 msg) of
-        Left _ -> sendStatusJSON internalServerError500 $ object ["msg" .= ("Unable to encrypt input" :: Text)]
+        Left _ -> sendStatusJSON internalServerError500 $ object ["msg" .= ("Unable to cipher input" :: Text)]
         Right eMsg ->
             pure $
                 object
                     [ "message" .= msg
-                    , "encrypted" .= show eMsg
+                    , "cipher" .= Base64.encodeBase64 eMsg
                     ]

--- a/src/Handler/Decipher.hs
+++ b/src/Handler/Decipher.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Handler.Decipher where
+
+import qualified Data.ByteString.Base64.URL as Base64
+import qualified Data.Cipher as Cipher
+import qualified Data.Text.Encoding as Text
+import Import
+
+getDecipherR :: Text -> HandlerFor App Value
+getDecipherR cipher' = do
+    App{appCipherSecretKey = sk, appCipherInitializationVector = iv} <- getYesod
+    let eCipher = Base64.decodeBase64 (Text.encodeUtf8 cipher')
+        encryptionError = sendStatusJSON internalServerError500 $ object ["msg" .= ("Unable to decipher input" :: Text)]
+    case eCipher of
+        Left _ -> encryptionError
+        Right cipher -> do
+            case Cipher.decrypt sk iv cipher of
+                Left _ -> encryptionError
+                Right decipher ->
+                    pure $
+                        object
+                            [ "message" .= cipher'
+                            , "decipher" .= Text.decodeUtf8 decipher
+                            ]

--- a/src/Handler/Hash.hs
+++ b/src/Handler/Hash.hs
@@ -1,34 +1,54 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Handler.Hash where
 
 import Crypto.Hash
-import Crypto.Hash.Algorithms
+import qualified Data.ByteArray as ByteArray
+import qualified Data.ByteArray.Encoding as ByteArray
+import qualified Data.ByteString as ByteString
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Import
 
-data HasHashAlgorithm where
-    HasHashAlgorithm :: HashAlgorithm a => a -> HasHashAlgorithm
+data HasHash where
+    HasHash :: (HashAlgorithm alg, ByteArray.ByteArrayAccess ba) => alg -> ba -> HasHash
 
-elimHasHashAlgorithm ::
-    forall a.
-    HashAlgorithm a =>
-    (a -> Digest a) ->
-    HasHashAlgorithm ->
-    Digest a
-elimHasHashAlgorithm f (HasHashAlgorithm algo) = f algo
+elimHasHash ::
+    ByteArray.Base ->
+    (forall alg ba. (HashAlgorithm alg, ByteArray.ByteArrayAccess ba) => alg -> ba -> Digest alg) ->
+    HasHash ->
+    ByteString.ByteString
+elimHasHash base f (HasHash alg ba) = ByteArray.convertToBase base $ f alg ba
 
-toAlgorithm :: Text -> HasHashAlgorithm
-toAlgorithm alg = case Text.toLower alg of
-    "md5" -> HasHashAlgorithm MD5
-    "sha1" -> HasHashAlgorithm SHA1
+toHash :: Text -> ByteString.ByteString -> Maybe HasHash
+toHash alg ba = case Text.toLower alg of
+    "md5" -> Just $ HasHash MD5 ba
+    "sha1" -> Just $ HasHash SHA1 ba
+    "sha256" -> Just $ HasHash SHA256 ba
+    _ -> Nothing
+
+toBase :: Maybe Text -> ByteArray.Base
+toBase = maybe ByteArray.Base16 $ \case
+    "base16" -> ByteArray.Base16
+    "base32" -> ByteArray.Base32
+    "base64" -> ByteArray.Base64
+    _ -> ByteArray.Base16
 
 getHashR :: Text -> Text -> HandlerFor App Value
 getHashR algoText msg = do
-    let hash = elimHasHashAlgorithm (\algo -> hashWith algo (Text.encodeUtf8 msg)) (toAlgorithm algoText)
-    pure Null
+    base <- toBase <$> lookupGetParam "base"
+    h <- case toHash algoText (Text.encodeUtf8 msg) of
+        Just hasHash -> pure $ elimHasHash base hashWith hasHash
+        Nothing -> notFound
+    pure $
+        object
+            [ "output" .= Text.decodeUtf8 h
+            , "algorithm" .= algoText
+            , "input" .= msg
+            ]

--- a/src/Handler/Hash.hs
+++ b/src/Handler/Hash.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Handler.Hash where
+
+import Crypto.Hash
+import Crypto.Hash.Algorithms
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Import
+
+data HasHashAlgorithm where
+    HasHashAlgorithm :: HashAlgorithm a => a -> HasHashAlgorithm
+
+elimHasHashAlgorithm ::
+    forall a.
+    HashAlgorithm a =>
+    (a -> Digest a) ->
+    HasHashAlgorithm ->
+    Digest a
+elimHasHashAlgorithm f (HasHashAlgorithm algo) = f algo
+
+toAlgorithm :: Text -> HasHashAlgorithm
+toAlgorithm alg = case Text.toLower alg of
+    "md5" -> HasHashAlgorithm MD5
+    "sha1" -> HasHashAlgorithm SHA1
+
+getHashR :: Text -> Text -> HandlerFor App Value
+getHashR algoText msg = do
+    let hash = elimHasHashAlgorithm (\algo -> hashWith algo (Text.encodeUtf8 msg)) (toAlgorithm algoText)
+    pure Null


### PR DESCRIPTION
- `GET /api/hash/md5/derp` will return the MD5 hash of `derp`, `sha1` and `sha256` also supported
- `GET /api/cipher/aes256/derp` will return the aes256 cipher of `derp` using the applications secret key
- `GET /api/decipher/aes256/{cipher}` will attempt to decipher the text using the applications secret key, requires base64 encoding
